### PR TITLE
Update README.md and longer cluster example

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A simple performant way to use [socket.io](http://socket.io/) with a
 
 ## Technical
 
-Sticky Sessions are Hash Balanced by IP. Optionally layer4 header informations, for proxied connections, can be hashed.
+Sticky sessions are hash balanced by IP. Optionally, layer4 header information (HTTP) for reverse-proxied connections can be hashed.
 
 ### Prolog to Proxied connections
 
@@ -17,7 +17,7 @@ before they reach the node Application.
 #### The Problem:
 
 If we proxy any connection, the real IP will be lost. The original implementation of sticky-sessions
-worked only on layer 3 of the OSI Model. But the Information we need, is right now on layer 4.
+worked only on layer 3 of the OSI Model. But the information we need, is right now on layer 4.
 
 **Note:** Only versions smaller than 0.11.14 and greater than 0.9.6 are supported.
 The reason for this is that the behavior of onread in net.js has changed:

--- a/example/cluster.js
+++ b/example/cluster.js
@@ -1,0 +1,23 @@
+var sticky = require('../');
+var cluster = require('cluster');
+var port = 3000;
+var http = require('http');
+
+var createServer = function () {
+    return http.createServer(function(req, res) {
+      res.writeHead(200, {'Content-Type': 'text/plain'});
+      res.end('Hello World! From worker '
+        + (cluster.isMaster ? 'master' : cluster.worker.id)
+        + ' with pid: ' + process.pid + ' \n');
+    });
+};
+
+var stickyOptions = {
+  proxy: false //activate layer 4 patching
+}
+
+var server = sticky(stickyOptions, createServer).listen(port, function() {
+    console.log('Sticky cluster worker '
+      + (cluster.worker ? cluster.worker.id : 'master')
+      + ' server listening on port ' + port);
+});


### PR DESCRIPTION
This just adds a more verbose cluster example. I was confused by the other example and thought I had to implement cluster myself; I didn't realize it was built-in. Also the cluster.js is handy for testing.