### PR TITLE
Fixed: wrong IP address search in request header

### DIFF
--- a/lib/sticky-session.js
+++ b/lib/sticky-session.js
@@ -248,7 +248,6 @@ StickyAgent.prototype.listener = function(msg, socket) {
       socket.once('data', function(data) {
         var strData = data.toString().toLowerCase();
         var searchPos = strData.indexOf(self.header);
-        var endPos = 0;
 
         if( self.serverOptions.pauseOnConnect )
           socket.pause();
@@ -271,9 +270,10 @@ StickyAgent.prototype.listener = function(msg, socket) {
 
         searchPos = strData.indexOf(':', searchPos) + 1;
 
-        endPos = strData.search(/\r\n|\r|\n/, searchPos);
-        strData = strData.substr(searchPos, endPos).trim();
+        strData = strData.slice(searchPos);
 
+        var endPos = strData.search(/\r\n|\r|\n/);
+        strData = strData.substr(searchPos, endPos).trim();
 
         //Send ackknownledge + data and real ip adress back to master
         process.send(


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/search

There is one parameter in String.searh function. So search start from begining of strData variable and searchPos variable was ignored.