### PR TITLE
fix: bug that does not work if the option value is not entered

### DIFF
--- a/lib/sticky-session.js
+++ b/lib/sticky-session.js
@@ -116,6 +116,12 @@ function StickyAgent(options, callback) {
   };
   this.serverOptions = {};
 
+  if (Number(version.substr(0, index)) >= 1 
+    || Number(version.substr(index + 1)) >= 12) {
+    this.serverOptions.pauseOnConnect = true;
+    this.republishPacket = node012Republish;
+  }
+
   // `num` argument is optional
   if (!callback) {
     this.callback = options;
@@ -158,12 +164,6 @@ function StickyAgent(options, callback) {
       */
     if (options.sync) {
       this.sync = options.sync;
-    }
-
-    if (Number(version.substr(0, index)) >= 1 ||
-        Number(version.substr(index + 1)) >= 12) {
-      this.serverOptions.pauseOnConnect = true;
-      this.republishPacket = node012Republish;
     }
   }
 }


### PR DESCRIPTION
* Even if no options value is entered, `serverOptions.pauseOnConnect` and `republishPacket` are automatically set.

I found this issue in node v12.22.4 version.

related: #3